### PR TITLE
Fix quant trading lesson links

### DIFF
--- a/lessons/quant-course.html
+++ b/lessons/quant-course.html
@@ -486,7 +486,7 @@
               </div>
               <h3>Backtesting & Strategy Evaluation</h3>
               <p>Build robust backtesting frameworks and learn how to properly evaluate and validate trading strategies.</p>
-              <a href="quant-trading/lesson-8-backtesting.html" class="lesson-btn">Start Learning</a>
+              <a href="quant-trading/lesson-8-backtesting-evaluation.html" class="lesson-btn">Start Learning</a>
               <div class="progress-indicator">
                 <span>Progress:</span>
                 <div class="progress-bar">

--- a/lessons/quant-trading/lesson-7-sentiment-analysis.html
+++ b/lessons/quant-trading/lesson-7-sentiment-analysis.html
@@ -1287,7 +1287,7 @@ class EventDrivenSentimentStrategy:
           <a href="lesson-6-portfolio-optimization.html" class="btn-nav btn-secondary">
             <i class="fa fa-arrow-left"></i> Previous: Portfolio Optimization
           </a>
-          <a href="lesson-8-backtesting.html" class="btn-nav btn-primary">
+          <a href="lesson-8-backtesting-evaluation.html" class="btn-nav btn-primary">
             Next: Backtesting & Strategy Evaluation <i class="fa fa-arrow-right"></i>
           </a>
         </div>

--- a/lessons/quant-trading/lesson-8-backtesting-evaluation.html
+++ b/lessons/quant-trading/lesson-8-backtesting-evaluation.html
@@ -133,9 +133,25 @@
             transform: translateY(-2px);
             box-shadow: 0 5px 15px rgba(40, 167, 69, 0.4);
         }
+
+        .back-link {
+            position: absolute;
+            top: 20px;
+            left: 20px;
+            color: #28a745;
+            font-size: 1.2rem;
+            text-decoration: none;
+            transition: all 0.3s ease;
+            z-index: 10;
+        }
+        .back-link:hover {
+            color: #1e7e34;
+            text-decoration: none;
+        }
     </style>
 </head>
 <body>
+    <a href="../quant-course.html" class="back-link"><i class="fa fa-arrow-left"></i> Back to Course</a>
     <div class="container">
         <div class="header">
             <h1>Lesson 8: Backtesting & Strategy Evaluation</h1>


### PR DESCRIPTION
## Summary
- fix broken link to lesson 8 in the Quant course overview
- update lesson 7 navigation to point to the correct lesson 8 file
- add back-to-course link and styles in lesson 8

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688ab076c62c8326bc30ef1025082c42