### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Matthew Frank
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -24,3 +24,6 @@ Welcome to the repository for my personal portfolio website, hosted at <a href="
 5. <a href="https://maafrank.github.io/#experience" target="_blank">**Experience**</a>: A detailed look at my professional journey.
 6. <a href="https://maafrank.github.io/#projects" target="_blank">**Projects**</a>: Highlights of my work and contributions to various projects.
 7. <a href="https://maafrank.github.io/#contact" target="_blank">**Contact**</a>: A form to reach out to me directly along with contact information.
+## License
+
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- add a standard MIT license file naming Matthew Frank as the copyright
  holder
- document the MIT license in `README.md`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688ab3f60da08326992b2fc74cfa4328