### PR TITLE
Remove console logs from lesson 8

### DIFF
--- a/lessons/quant-trading/lesson-8-backtesting-evaluation.html
+++ b/lessons/quant-trading/lesson-8-backtesting-evaluation.html
@@ -1413,8 +1413,6 @@ print("Run: mc_analyzer, results, analysis = run_monte_carlo_example()")
                 block.appendChild(copyButton);
             });
             
-            console.log('🎉 Lesson 8: Backtesting & Strategy Evaluation loaded successfully!');
-            console.log('🎓 Congratulations on completing the Quantitative Trading with ML course!');
         });
 
         // Mark lesson as completed when user scrolls to bottom


### PR DESCRIPTION
## Summary
- clean up debugging statements in Lesson 8 Backtesting & Strategy Evaluation

## Testing
- `grep -n "console" lessons/quant-trading/lesson-8-backtesting-evaluation.html`

------
https://chatgpt.com/codex/tasks/task_e_688ab40869c8832686700ae02032bea0