### PR TITLE
Improve contact form accessibility

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -38,13 +38,25 @@ font-family: 'Poppins', sans-serif;
 	box-sizing:border-box;
 }
 body{
-	font-family: 'Poppins', sans-serif;
-	font-size:16px;
-	color: #676a81;
-	background: #fff;
+        font-family: 'Poppins', sans-serif;
+        font-size:16px;
+        color: #676a81;
+        background: #fff;
     max-width:1920px;
     margin:0 auto;
-	overflow-x:hidden;
+        overflow-x:hidden;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 a,a:hover,a:active,a:focus {

--- a/index.html
+++ b/index.html
@@ -635,28 +635,36 @@
 	      <form>
 		<div class="row">
 		  <div class="col-sm-6 col-xs-12">
-		    <div class="form-group">
-		      <input type="text" class="form-control" id="name" placeholder="Name*" name="name">
-		    </div><!--/.form-group-->
-		  </div><!--/.col-->
-		  <div class="col-sm-6 col-xs-12">
-		    <div class="form-group">
-		      <input type="email" class="form-control" id="email" placeholder="Email*" name="email">
-		    </div><!--/.form-group-->
-		  </div><!--/.col-->
-		</div><!--/.row-->
-		<div class="row">
-		  <div class="col-sm-12">
-		    <div class="form-group">
-		      <input type="text" class="form-control" id="subject" placeholder="Subject" name="subject">
-		    </div><!--/.form-group-->
+                    <div class="form-group">
+                      <label for="name" class="sr-only">Name*
+                        <input type="text" class="form-control" id="name" placeholder="Name*" name="name">
+                      </label>
+                    </div><!--/.form-group-->
+                  </div><!--/.col-->
+                  <div class="col-sm-6 col-xs-12">
+                    <div class="form-group">
+                      <label for="email" class="sr-only">Email*
+                        <input type="email" class="form-control" id="email" placeholder="Email*" name="email">
+                      </label>
+                    </div><!--/.form-group-->
 		  </div><!--/.col-->
 		</div><!--/.row-->
 		<div class="row">
 		  <div class="col-sm-12">
-		    <div class="form-group">
-		      <textarea class="form-control" rows="8" id="comment" placeholder="Message" ></textarea>
-		    </div><!--/.form-group-->
+                    <div class="form-group">
+                      <label for="subject" class="sr-only">Subject
+                        <input type="text" class="form-control" id="subject" placeholder="Subject" name="subject">
+                      </label>
+                    </div><!--/.form-group-->
+		  </div><!--/.col-->
+		</div><!--/.row-->
+		<div class="row">
+		  <div class="col-sm-12">
+                    <div class="form-group">
+                      <label for="comment" class="sr-only">Message
+                        <textarea class="form-control" rows="8" id="comment" placeholder="Message" ></textarea>
+                      </label>
+                    </div><!--/.form-group-->
 		  </div><!--/.col-->
 		</div><!--/.row-->
 		<div class="row">


### PR DESCRIPTION
## Summary
- add `.sr-only` utility class in stylesheet
- wrap contact form inputs with `label` elements for accessibility

## Testing
- `htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_688ab41f0d248326a8bfd2aa6a9b962b