### PR TITLE
Standardize lesson 8 layout

### DIFF
--- a/lessons/quant-trading/lesson-8-backtesting-evaluation.html
+++ b/lessons/quant-trading/lesson-8-backtesting-evaluation.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Lesson 8: Backtesting & Strategy Evaluation - Quantitative Trading with ML</title>
+<!doctype html>
+<html class="no-js" lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Poppins:100,200,300,400,500,600,700,800,900&amp;subset=devanagari,latin-ext" rel="stylesheet">
+    <title>Lesson 8: Backtesting & Strategy Evaluation - Quantitative Trading Course</title>
+    <link rel="shortcut icon" type="image/icon" href="../../assets/logo/favicon.png"/>
+    <link rel="stylesheet" href="../../assets/css/font-awesome.min.css">
+    <link rel="stylesheet" href="../../assets/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../assets/css/bootsnav.css">
+    <link rel="stylesheet" href="../../assets/css/style.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.24.1/themes/prism-tomorrow.min.css" rel="stylesheet" />
     <style>
         body {
             font-family: 'Arial', sans-serif;
@@ -1356,6 +1364,9 @@ print("Run: mc_analyzer, results, analysis = run_monte_carlo_example()")
             <a href="../index.html" class="nav-button">🏠 Course Home</a>
         </div>
     </div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.24.1/components/prism-core.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.24.1/plugins/autoloader/prism-autoloader.min.js"></script>
 
     <script>
         // Add interactive elements and animations


### PR DESCRIPTION
## Summary
- update lesson 8 of the Quant Trading course so the header matches other lessons
- add Prism.js scripts for syntax highlighting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688abaaf4e808326b4e18f7bf9456c3d